### PR TITLE
修改 笔记/index.md 中 warning 样式不统一的问题

### DIFF
--- a/笔记/index.md
+++ b/笔记/index.md
@@ -62,7 +62,7 @@ git clone https://github.com/nolebase/nolebase
 
 #### 使用的是 Windows 吗
 
-> [!IMPORTANT]
+> [!WARNING] 注意
 > 如果你使用的是 [Git for Windows](https://gitforwindows.org/) ，那么可能会在执行上述命令时，遇到类似这样的报错：
 >
 > ```PowerShell


### PR DESCRIPTION
上次提交的 PR 把 warning 样式都写成了

```markdown
[!IMPORTANT]
```

导致了文档中有两种 warning 样式。现在已修复。

~~不懂前端~~